### PR TITLE
Fix two bug about single tasks and executor

### DIFF
--- a/src/main/java/com/baidu/hugegraph/loader/HugeGraphLoader.java
+++ b/src/main/java/com/baidu/hugegraph/loader/HugeGraphLoader.java
@@ -34,7 +34,6 @@ import com.baidu.hugegraph.driver.HugeClient;
 import com.baidu.hugegraph.loader.exception.LoadException;
 import com.baidu.hugegraph.loader.exception.ParseException;
 import com.baidu.hugegraph.loader.executor.GroovyExecutor;
-import com.baidu.hugegraph.loader.executor.HugeClients;
 import com.baidu.hugegraph.loader.executor.LoadLogger;
 import com.baidu.hugegraph.loader.executor.LoadOptions;
 import com.baidu.hugegraph.loader.executor.LoadSummary;
@@ -46,6 +45,8 @@ import com.baidu.hugegraph.loader.source.EdgeSource;
 import com.baidu.hugegraph.loader.source.GraphSource;
 import com.baidu.hugegraph.loader.source.VertexSource;
 import com.baidu.hugegraph.loader.task.TaskManager;
+import com.baidu.hugegraph.loader.util.HugeClientWrapper;
+import com.baidu.hugegraph.loader.util.LoaderUtil;
 import com.baidu.hugegraph.structure.graph.Edge;
 import com.baidu.hugegraph.structure.graph.Vertex;
 import com.baidu.hugegraph.util.E;
@@ -57,7 +58,7 @@ public class HugeGraphLoader {
     private static final Logger LOG = Log.logger(HugeGraphLoader.class);
     private static final LoadLogger LOG_PARSE = LoadLogger.logger("parseError");
 
-    private final JCommander commander;
+    private final LoadOptions options;
     private final TaskManager taskManager;
     private final GraphSource graphSource;
 
@@ -65,79 +66,67 @@ public class HugeGraphLoader {
 
     public static void main(String[] args) {
         HugeGraphLoader loader = new HugeGraphLoader(args);
-        LoadSummary summary = loader.load();
-        summary.print();
+        loader.load();
     }
 
     private HugeGraphLoader(String[] args) {
-        LoadOptions options = LoadOptions.instance();
-        this.commander = JCommander.newBuilder().addObject(options).build();
+        this.options = new LoadOptions();
         this.parseAndCheckOptions(args);
-        this.taskManager = new TaskManager(options);
-        this.graphSource = GraphSource.of(options.file);
+        this.taskManager = new TaskManager(this.options);
+        this.graphSource = GraphSource.of(this.options.file);
     }
 
     private void parseAndCheckOptions(String[] args) {
-        this.commander.parse(args);
+        JCommander commander = JCommander.newBuilder()
+                                         .addObject(this.options)
+                                         .build();
+        commander.parse(args);
+        // Print usage and exit
+        if (this.options.help) {
+            LoaderUtil.exitWithUsage(commander, 0);
+        }
         // Check options
-        LoadOptions options = LoadOptions.instance();
         // Check option "-f"
-        E.checkArgument(!StringUtils.isEmpty(options.file),
+        E.checkArgument(!StringUtils.isEmpty(this.options.file),
                         "Must specified entrance groovy file");
-        File scriptFile = new File(options.file);
+        File scriptFile = new File(this.options.file);
         if (!scriptFile.canRead()) {
             LOG.error("Script file must be readable: '{}'",
                       scriptFile.getAbsolutePath());
-            this.exitWithUsage(-1);
+            LoaderUtil.exitWithUsage(commander, -1);
         }
         // Check option "-g"
-        E.checkArgument(!StringUtils.isEmpty(options.graph),
+        E.checkArgument(!StringUtils.isEmpty(this.options.graph),
                         "Must specified a graph");
         // Check option "-h"
-        if (!options.host.startsWith("http://")) {
-            options.host = "http://" + options.host;
+        if (!this.options.host.startsWith("http://")) {
+            this.options.host = "http://" + this.options.host;
         }
     }
 
-    private LoadSummary load() {
+    private void load() {
         // Create schema
         this.createSchema();
 
-        LoadSummary summary = new LoadSummary();
-        // Prepare to load vertices
-        Instant begTime = Instant.now();
-        System.out.print("Vertices has been imported: 0\b\b");
         // Load vertices
-        this.loadVertices();
-        Instant endTime = Instant.now();
-        Duration duration = Duration.between(begTime, endTime);
-        summary.parseFailureVertices(this.parseFailureNum);
-        summary.insertFailureVertices(this.taskManager.failureNum());
-        summary.insertSuccessVertices(this.taskManager.successNum());
-        summary.vertexLoadTime(duration);
-        System.out.println(" " + summary.insertSuccessVertices());
+        System.out.print("Vertices has been imported: 0\b");
+        LoadSummary vertexSummary = this.loadVertices();
+        System.out.println(vertexSummary.insertSuccess());
         // Reset counters
         this.resetCounters();
 
-        // Prepare to load edges ...
-        begTime = Instant.now();
-        System.out.print("Edges has been imported: 0\b\b");
         // Load edges
-        this.loadEdges();
-        endTime = Instant.now();
-        duration = Duration.between(begTime, endTime);
-        summary.parseFailureEdges(this.parseFailureNum);
-        summary.insertFailureEdges(this.taskManager.failureNum());
-        summary.insertSuccessEdges(this.taskManager.successNum());
-        summary.edgeLoadTime(duration);
-        System.out.println(" " + summary.insertSuccessEdges());
+        System.out.print("Edges has been imported: 0\b");
+        LoadSummary edgeSummary = this.loadEdges();
+        System.out.println(edgeSummary.insertSuccess());
         // Reset counters
         this.resetCounters();
 
-        LoadOptions options = LoadOptions.instance();
+        // Print load summary
+        LoaderUtil.printSummary(vertexSummary, edgeSummary);
+
         // Shutdown task manager
-        this.taskManager.shutdown(options.shutdownTimeout);
-        return summary;
+        this.shutdown(this.options.shutdownTimeout);
     }
 
     private void resetCounters() {
@@ -145,10 +134,13 @@ public class HugeGraphLoader {
         this.parseFailureNum = 0L;
     }
 
+    private void shutdown(int seconds) {
+        this.taskManager.shutdown(seconds);
+    }
+
     private void createSchema() {
-        LoadOptions options = LoadOptions.instance();
-        File schemaFile = FileUtils.getFile(options.schema);
-        HugeClient client = HugeClients.get(options);
+        File schemaFile = FileUtils.getFile(this.options.schema);
+        HugeClient client = HugeClientWrapper.get(this.options);
         GroovyExecutor groovyExecutor = new GroovyExecutor();
         groovyExecutor.bind("schema", client.schema());
         String script;
@@ -156,44 +148,65 @@ public class HugeGraphLoader {
             script = FileUtils.readFileToString(schemaFile, "UTF-8");
         } catch (IOException e) {
             throw new LoadException("Read schema file '%s' error",
-                                    e, options.schema);
+                                    e, this.options.schema);
         }
         groovyExecutor.execute(script, client);
     }
 
-    private void loadVertices() {
-        LoadOptions options = LoadOptions.instance();
+    private LoadSummary loadVertices() {
+        Instant beginTime = Instant.now();
+
+        // Execute loading tasks
         List<VertexSource> vertexSources = this.graphSource.vertexSources();
         for (VertexSource source : vertexSources) {
+            LOG.info("Loading vertex source '{}'", source.label());
             InputReader reader = InputReaderFactory.create(source.input());
-            VertexParser parser = new VertexParser(source, reader);
-            this.loadVertex(parser);
             try {
-                parser.close();
-            } catch (Exception e) {
-                LOG.warn("Failed to close parser for vertex source {}", source);
+                VertexParser parser = new VertexParser(source, reader,
+                                                       this.options);
+                this.loadVertex(parser);
+            } finally {
+                try {
+                    reader.close();
+                } catch (Throwable e) {
+                    LOG.warn("Failed to close reader for vertex source {} " +
+                             "with exception {}", source, e);
+                }
             }
         }
         // Waiting async worker threads finish
-        this.taskManager.waitFinished(options.timeout);
+        this.taskManager.waitFinished("vertices");
+
+        Instant endTime = Instant.now();
+
+        LoadSummary summary = new LoadSummary("vertices");
+        Duration duration = Duration.between(beginTime, endTime);
+        summary.parseFailure(this.parseFailureNum);
+        summary.insertFailure(this.taskManager.failureNum());
+        summary.insertSuccess(this.taskManager.successNum());
+        summary.loadTime(duration);
+
+        return summary;
     }
 
     private void loadVertex(VertexParser parser) {
-        LoadOptions options = LoadOptions.instance();
-        int batchSize = options.batchSize;
+        int batchSize = this.options.batchSize;
         List<Vertex> batch = new ArrayList<>(batchSize);
         while (parser.hasNext()) {
             try {
                 Vertex vertex = parser.next();
                 batch.add(vertex);
             } catch (ParseException e) {
-                if (options.testMode) {
+                if (this.options.testMode) {
                     throw e;
                 }
                 LOG.error("Vertex parse error", e);
                 LOG_PARSE.error(e);
-                if (++this.parseFailureNum >= options.maxParseErrors) {
-                    exitWithInfo("vertices", options.maxParseErrors);
+                if (++this.parseFailureNum >= this.options.maxParseErrors) {
+                    LoaderUtil.printError("Error: More than %s vertices " +
+                                          "parsing error ... Stopping",
+                                          this.options.maxParseErrors);
+                    System.exit(-1);
                 }
                 continue;
             }
@@ -207,39 +220,59 @@ public class HugeGraphLoader {
         }
     }
 
-    private void loadEdges() {
-        LoadOptions options = LoadOptions.instance();
+    private LoadSummary loadEdges() {
+        Instant beginTime = Instant.now();
+
         List<EdgeSource> edgeSources = this.graphSource.edgeSources();
         for (EdgeSource source : edgeSources) {
+            LOG.info("Loading edge source '{}'", source.label());
             InputReader reader = InputReaderFactory.create(source.input());
-            EdgeParser parser = new EdgeParser(source, reader);
-            this.loadEdge(parser);
             try {
-                parser.close();
-            } catch (Exception e) {
-                LOG.warn("Failed to close parser for edge source {}", source);
+                EdgeParser parser = new EdgeParser(source, reader,
+                                                   this.options);
+                this.loadEdge(parser);
+            } finally {
+                try {
+                    reader.close();
+                } catch (Throwable e) {
+                    LOG.warn("Failed to close reader for edge source {} " +
+                             "with exception {}", source, e);
+                }
             }
         }
         // Waiting async worker threads finish
-        this.taskManager.waitFinished(options.timeout);
+        this.taskManager.waitFinished("edges");
+
+        Instant endTime = Instant.now();
+
+        LoadSummary summary = new LoadSummary("edges");
+        Duration duration = Duration.between(beginTime, endTime);
+        summary.parseFailure(this.parseFailureNum);
+        summary.insertFailure(this.taskManager.failureNum());
+        summary.insertSuccess(this.taskManager.successNum());
+        summary.loadTime(duration);
+
+        return summary;
     }
 
     private void loadEdge(EdgeParser parser) {
-        LoadOptions options = LoadOptions.instance();
-        int batchSize = options.batchSize;
+        int batchSize = this.options.batchSize;
         List<Edge> batch = new ArrayList<>(batchSize);
         while (parser.hasNext()) {
             try {
                 Edge edge = parser.next();
                 batch.add(edge);
             } catch (ParseException e) {
-                if (options.testMode) {
+                if (this.options.testMode) {
                     throw e;
                 }
                 LOG.error("Edge parse error", e);
                 LOG_PARSE.error(e);
-                if (++this.parseFailureNum >= options.maxParseErrors) {
-                    exitWithInfo("edges", options.maxParseErrors);
+                if (++this.parseFailureNum >= this.options.maxParseErrors) {
+                    LoaderUtil.printError("Error: More than %s edges " +
+                                          "parsing error ... Stopping",
+                                          this.options.maxParseErrors);
+                    System.exit(-1);
                 }
                 continue;
             }
@@ -251,20 +284,5 @@ public class HugeGraphLoader {
         if (batch.size() > 0) {
             this.taskManager.submitEdgeBatch(batch);
         }
-    }
-
-    private void exitWithUsage(int status) {
-        this.commander.usage();
-        System.exit(status);
-    }
-
-    private static void exitWithInfo(String type, int parseErrors) {
-        LOG.error("Too many {} parse error ... Stopping", type);
-        // Print an empty line.
-        System.out.println();
-        System.out.println(String.format(
-                           "Error: More than %s %s parsing error ... Stopping",
-                           parseErrors, type));
-        System.exit(0);
     }
 }

--- a/src/main/java/com/baidu/hugegraph/loader/executor/LoadOptions.java
+++ b/src/main/java/com/baidu/hugegraph/loader/executor/LoadOptions.java
@@ -21,25 +21,12 @@ package com.baidu.hugegraph.loader.executor;
 
 import java.io.File;
 
-import org.slf4j.Logger;
-
-import com.baidu.hugegraph.util.Log;
 import com.beust.jcommander.IParameterValidator;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 
 public class LoadOptions {
-
-    private Logger LOG = Log.logger(LoadOptions.class);
-
-    private static final LoadOptions instance = new LoadOptions();
-
-    public static LoadOptions instance() {
-        return instance;
-    }
-
-    private LoadOptions() {}
-
+    
     @Parameter(names = {"-f", "--file"}, required = true, arity = 1,
                validateWith = {FileValidator.class},
                description = "The path of the data source description file")
@@ -67,7 +54,7 @@ public class LoadOptions {
     @Parameter(names = {"--num-threads"}, arity = 1,
                validateWith = {PositiveValidator.class},
                description = "The number of threads to use")
-    public int numThreads = Runtime.getRuntime().availableProcessors() * 2 - 1;
+    public int numThreads = Runtime.getRuntime().availableProcessors();
 
     @Parameter(names = {"--batch-size"}, arity = 1,
                validateWith = {PositiveValidator.class},
@@ -97,8 +84,8 @@ public class LoadOptions {
 
     @Parameter(names = {"--timeout"}, arity = 1,
                validateWith = {PositiveValidator.class},
-               description = "The timeout of inserting task in seconds")
-    public int timeout = 100;
+               description = "The timeout of HugeClient request")
+    public int timeout = 60;
 
     @Parameter(names = {"--retry-times"}, arity = 1,
                validateWith = {PositiveValidator.class},
@@ -113,6 +100,10 @@ public class LoadOptions {
     @Parameter(names = {"--test-mode"}, arity = 1,
                description = "Whether the hugegraph-loader work in test mode")
     public boolean testMode = false;
+
+    @Parameter(names = {"--help"}, help = true,
+               description = "Print usage of HugeGraphLoader")
+    public boolean help;
 
     public static class UrlValidator implements IParameterValidator {
 

--- a/src/main/java/com/baidu/hugegraph/loader/executor/LoadSummary.java
+++ b/src/main/java/com/baidu/hugegraph/loader/executor/LoadSummary.java
@@ -20,117 +20,57 @@
 package com.baidu.hugegraph.loader.executor;
 
 import java.time.Duration;
-import java.util.Formatter;
 
 public class LoadSummary {
 
-    private static Formatter formatter = new Formatter(System.out);
+    private final String type;
 
-    private long parseFailureVertices;
-    private long insertFailureVertices;
-    private long insertSuccessVertices;
+    private long parseFailure;
+    private long insertFailure;
+    private long insertSuccess;
+    private Duration loadTime;
 
-    private long parseFailureEdges;
-    private long insertFailureEdges;
-    private long insertSuccessEdges;
-
-    private Duration vertexLoadTime;
-    private Duration edgeLoadTime;
-
-    public LoadSummary() {
-        this.vertexLoadTime = Duration.ZERO;
-        this.edgeLoadTime = Duration.ZERO;
+    public LoadSummary(String type) {
+        this.type = type;
+        this.parseFailure = 0L;
+        this.insertFailure = 0L;
+        this.insertSuccess = 0L;
+        this.loadTime = Duration.ZERO;
     }
 
-    public void print() {
-        System.out.println("-------------------------------------------------");
-        System.out.println("Vertex Results:");
-        printInFormat("Parse failure vertices", this.parseFailureVertices());
-        printInFormat("Insert failure vertices", this.insertFailureVertices());
-        printInFormat("Insert success vertices", this.insertSuccessVertices());
-
-        System.out.println("-------------------------------------------------");
-        System.out.println("Edge Results:");
-        printInFormat("Parse failure edges", this.parseFailureEdges());
-        printInFormat("Insert failure edges", this.insertFailureEdges());
-        printInFormat("Insert success edges", this.insertSuccessEdges());
-
-        System.out.println("-------------------------------------------------");
-        System.out.println("Time Results:");
-        printInFormat("Vertex loading time", this.vertexLoadTime().getSeconds());
-        printInFormat("Edge loading time", this.edgeLoadTime().getSeconds());
-        printInFormat("Total loading time", this.totalTime().getSeconds());
+    public String type() {
+        return this.type;
     }
 
-    private static void printInFormat(String desc, long value) {
-        formatter.format("\t%-25s:\t%-20d%n", desc, value);
+    public long parseFailure() {
+        return this.parseFailure;
     }
 
-    private Duration totalTime() {
-        return edgeLoadTime().plus(vertexLoadTime());
+    public void parseFailure(long count) {
+        this.parseFailure = count;
     }
 
-    public Duration vertexLoadTime() {
-        return this.vertexLoadTime;
+    public long insertFailure() {
+        return this.insertFailure;
     }
 
-    public void vertexLoadTime(Duration duration) {
-        this.vertexLoadTime = duration;
+    public void insertFailure(long count) {
+        this.insertFailure = count;
     }
 
-    public Duration edgeLoadTime() {
-        return this.edgeLoadTime;
+    public long insertSuccess() {
+        return this.insertSuccess;
     }
 
-    public void edgeLoadTime(Duration duration) {
-        this.edgeLoadTime = duration;
+    public void insertSuccess(long count) {
+        this.insertSuccess = count;
     }
 
-    public long parseFailureVertices() {
-        return this.parseFailureVertices;
+    public Duration loadTime() {
+        return this.loadTime;
     }
 
-    public void parseFailureVertices(long count) {
-        this.parseFailureVertices = count;
-    }
-
-    public long insertFailureVertices() {
-        return this.insertFailureVertices;
-    }
-
-    public void insertFailureVertices(long count) {
-        this.insertFailureVertices = count;
-    }
-
-    public long insertSuccessVertices() {
-        return this.insertSuccessVertices;
-    }
-
-    public void insertSuccessVertices(long count) {
-        this.insertSuccessVertices = count;
-    }
-
-    public long parseFailureEdges() {
-        return this.parseFailureEdges;
-    }
-
-    public void parseFailureEdges(long count) {
-        this.parseFailureEdges = count;
-    }
-
-    public long insertFailureEdges() {
-        return this.insertFailureEdges;
-    }
-
-    public void insertFailureEdges(long count) {
-        this.insertFailureEdges = count;
-    }
-
-    public long insertSuccessEdges() {
-        return this.insertSuccessEdges;
-    }
-
-    public void insertSuccessEdges(long count) {
-        this.insertSuccessEdges = count;
+    public void loadTime(Duration duration) {
+        this.loadTime = duration;
     }
 }

--- a/src/main/java/com/baidu/hugegraph/loader/parser/EdgeParser.java
+++ b/src/main/java/com/baidu/hugegraph/loader/parser/EdgeParser.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import com.baidu.hugegraph.loader.executor.LoadOptions;
 import com.baidu.hugegraph.loader.reader.InputReader;
 import com.baidu.hugegraph.loader.source.EdgeSource;
 import com.baidu.hugegraph.structure.constant.IdStrategy;
@@ -38,8 +39,9 @@ public class EdgeParser extends ElementParser<Edge> {
     private final VertexLabel sourceLabel;
     private final VertexLabel targetLabel;
 
-    public EdgeParser(EdgeSource source, InputReader reader) {
-        super(reader);
+    public EdgeParser(EdgeSource source, InputReader reader,
+                      LoadOptions options) {
+        super(reader, options);
         this.source = source;
         this.edgeLabel = this.getEdgeLabel(source.label());
         this.sourceLabel = this.getVertexLabel(this.edgeLabel.sourceLabel());

--- a/src/main/java/com/baidu/hugegraph/loader/parser/ElementParser.java
+++ b/src/main/java/com/baidu/hugegraph/loader/parser/ElementParser.java
@@ -20,6 +20,7 @@
 package com.baidu.hugegraph.loader.parser;
 
 import java.io.UnsupportedEncodingException;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -27,12 +28,11 @@ import org.apache.commons.lang3.StringUtils;
 
 import com.baidu.hugegraph.driver.HugeClient;
 import com.baidu.hugegraph.loader.exception.ParseException;
-import com.baidu.hugegraph.loader.executor.HugeClients;
 import com.baidu.hugegraph.loader.executor.LoadOptions;
 import com.baidu.hugegraph.loader.reader.InputReader;
 import com.baidu.hugegraph.loader.source.ElementSource;
-import com.baidu.hugegraph.loader.util.AutoCloseableIterator;
 import com.baidu.hugegraph.loader.util.DataTypeUtil;
+import com.baidu.hugegraph.loader.util.HugeClientWrapper;
 import com.baidu.hugegraph.structure.GraphElement;
 import com.baidu.hugegraph.structure.SchemaElement;
 import com.baidu.hugegraph.structure.constant.HugeType;
@@ -45,7 +45,7 @@ import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.Table;
 
 public abstract class ElementParser<GE extends GraphElement>
-       implements AutoCloseableIterator<GE> {
+       implements Iterator<GE> {
 
     private static final int VERTEX_ID_LIMIT = 128;
     private static final String ID_CHARSET = "UTF-8";
@@ -55,9 +55,9 @@ public abstract class ElementParser<GE extends GraphElement>
     private final HugeClient client;
     private final Table<HugeType, String, SchemaElement> schemas;
 
-    ElementParser(InputReader reader) {
+    ElementParser(InputReader reader, LoadOptions options) {
         this.reader = reader;
-        this.client = HugeClients.get(LoadOptions.instance());
+        this.client = HugeClientWrapper.get(options);
         this.schemas = HashBasedTable.create();
         this.reader.init();
     }
@@ -81,11 +81,6 @@ public abstract class ElementParser<GE extends GraphElement>
         } catch (IllegalArgumentException e) {
             throw new ParseException(line, e.getMessage());
         }
-    }
-
-    @Override
-    public void close() throws Exception {
-        this.reader.close();
     }
 
     protected abstract GE parse(Map<String, Object> keyValues);

--- a/src/main/java/com/baidu/hugegraph/loader/parser/VertexParser.java
+++ b/src/main/java/com/baidu/hugegraph/loader/parser/VertexParser.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import com.baidu.hugegraph.loader.executor.LoadOptions;
 import com.baidu.hugegraph.loader.reader.InputReader;
 import com.baidu.hugegraph.loader.source.VertexSource;
 import com.baidu.hugegraph.structure.constant.IdStrategy;
@@ -35,8 +36,9 @@ public class VertexParser extends ElementParser<Vertex> {
     private final VertexSource source;
     private final VertexLabel vertexLabel;
 
-    public VertexParser(VertexSource source, InputReader reader) {
-        super(reader);
+    public VertexParser(VertexSource source, InputReader reader,
+                        LoadOptions options) {
+        super(reader, options);
         this.source = source;
         this.vertexLabel = this.getVertexLabel(source.label());
         // Ensure the id field is matched with id strategy

--- a/src/main/java/com/baidu/hugegraph/loader/task/EdgeInsertionTask.java
+++ b/src/main/java/com/baidu/hugegraph/loader/task/EdgeInsertionTask.java
@@ -24,15 +24,14 @@ import java.util.List;
 import com.baidu.hugegraph.loader.executor.LoadOptions;
 import com.baidu.hugegraph.structure.graph.Edge;
 
-public class InsertEdgeTask extends InsertTask<Edge> {
+public class EdgeInsertionTask extends InsertionTask<Edge> {
 
-    InsertEdgeTask(List<Edge> batch) {
-        super(batch);
+    public EdgeInsertionTask(List<Edge> batch, LoadOptions options) {
+        super(batch, options);
     }
 
     @Override
     protected void execute() {
-        LoadOptions options = LoadOptions.instance();
-        this.client().graph().addEdges(this.batch(), options.checkVertex);
+        this.client().graph().addEdges(this.batch(), this.options().checkVertex);
     }
 }

--- a/src/main/java/com/baidu/hugegraph/loader/task/VertexInsertionTask.java
+++ b/src/main/java/com/baidu/hugegraph/loader/task/VertexInsertionTask.java
@@ -17,29 +17,21 @@
  * under the License.
  */
 
-package com.baidu.hugegraph.loader.executor;
+package com.baidu.hugegraph.loader.task;
 
-import com.baidu.hugegraph.driver.HugeClient;
+import java.util.List;
+
 import com.baidu.hugegraph.loader.executor.LoadOptions;
+import com.baidu.hugegraph.structure.graph.Vertex;
 
-public class HugeClients {
+public class VertexInsertionTask extends InsertionTask<Vertex> {
 
-    // TODO: seems no need to use ThreadLocal, reuse HugeClient is ok
-    private static final ThreadLocal<HugeClient> instance = new ThreadLocal<>();
-
-    public static HugeClient get(LoadOptions options) {
-        HugeClient client = instance.get();
-        if (client == null) {
-            client = newHugeClient(options);
-            instance.set(client);
-        }
-        return client;
+    public VertexInsertionTask(List<Vertex> batch, LoadOptions options) {
+        super(batch, options);
     }
 
-    private HugeClients() {}
-
-    private static HugeClient newHugeClient(LoadOptions options) {
-        String address = options.host + ":" + options.port;
-        return new HugeClient(address, options.graph, options.timeout);
+    @Override
+    protected void execute() {
+        this.client().graph().addVertices(this.batch());
     }
 }

--- a/src/main/java/com/baidu/hugegraph/loader/util/HugeClientWrapper.java
+++ b/src/main/java/com/baidu/hugegraph/loader/util/HugeClientWrapper.java
@@ -17,20 +17,30 @@
  * under the License.
  */
 
-package com.baidu.hugegraph.loader.task;
+package com.baidu.hugegraph.loader.util;
 
-import java.util.List;
+import com.baidu.hugegraph.driver.HugeClient;
+import com.baidu.hugegraph.loader.executor.LoadOptions;
 
-import com.baidu.hugegraph.structure.graph.Vertex;
+public final class HugeClientWrapper {
 
-public class InsertVertexTask extends InsertTask<Vertex>  {
+    private static volatile HugeClient instance;
 
-    InsertVertexTask(List<Vertex> batch) {
-        super(batch);
+    public static HugeClient get(LoadOptions options) {
+        if (instance == null) {
+            synchronized(HugeClientWrapper.class) {
+                if (instance == null) {
+                    instance = newHugeClient(options);
+                }
+            }
+        }
+        return instance;
     }
 
-    @Override
-    protected void execute() {
-        this.client().graph().addVertices(this.batch());
+    private HugeClientWrapper() {}
+
+    private static HugeClient newHugeClient(LoadOptions options) {
+        String address = options.host + ":" + options.port;
+        return new HugeClient(address, options.graph, options.timeout);
     }
 }

--- a/src/main/java/com/baidu/hugegraph/loader/util/LoaderUtil.java
+++ b/src/main/java/com/baidu/hugegraph/loader/util/LoaderUtil.java
@@ -19,11 +19,78 @@
 
 package com.baidu.hugegraph.loader.util;
 
+import java.time.Duration;
+
+import org.slf4j.Logger;
+
+import com.baidu.hugegraph.loader.executor.LoadSummary;
+import com.baidu.hugegraph.util.Log;
+import com.beust.jcommander.JCommander;
+
 public final class LoaderUtil {
+
+    private static final Logger LOG = Log.logger(LoaderUtil.class);
+
+    public static void exitWithUsage(JCommander commander, int status) {
+        commander.usage();
+        System.exit(status);
+    }
+
+    public static void printError(String message, Object... args) {
+        String formattedMsg = String.format(message, args);
+        LOG.error(formattedMsg);
+        // Print an empty line.
+        System.err.println();
+        System.err.println(formattedMsg);
+    }
+
+    public static void printSummary(LoadSummary... summaries) {
+        // Print count
+        for (LoadSummary summary : summaries) {
+            String type = summary.type();
+            logAndPrint("---------------------------------------------");
+            logAndPrint(String.format("%s results:", type));
+            logAndPrint(String.format("parse failure %s", type),
+                        summary.parseFailure());
+            logAndPrint(String.format("insert failure %s", type),
+                        summary.insertFailure());
+            logAndPrint(String.format("insert success %s", type),
+                        summary.insertSuccess());
+        }
+        // Print time
+        logAndPrint("---------------------------------------------");
+        logAndPrint("time results:");
+        for (LoadSummary summary : summaries) {
+            String type = summary.type();
+            logAndPrint(String.format("%s loading time", type),
+                        summary.loadTime().getSeconds());
+        }
+        // Print total time
+        Duration totalTime = Duration.ZERO;
+        for (LoadSummary summary : summaries) {
+            totalTime = totalTime.plus(summary.loadTime());
+        }
+        logAndPrint("total loading time", totalTime.getSeconds());
+    }
+
+    private static void logAndPrint(String message) {
+        LOG.info(message);
+        System.out.println(message);
+    }
+
+    private static void logAndPrint(String desc, long value) {
+        String msg = String.format("\t%-25s:\t%-20d", desc, value);
+        logAndPrint(msg);
+    }
+
+    public static void printInBackward(long count) {
+        System.out.print(String.format("%d%s", count,
+                         LoaderUtil.backward(count)));
+    }
 
     public static String backward(long word) {
         StringBuilder backward = new StringBuilder();
-        for (int i = 0, len = String.valueOf(word).length(); i <= len; i++) {
+        for (int i = 0, len = String.valueOf(word).length(); i < len; i++) {
             backward.append("\b");
         }
         return backward.toString();


### PR DESCRIPTION
1. When a single insert task times out, it may still cause statistical errors.
2. TashManager.shutdown() ignored singleExecutor

Fix #11 
Change-Id: I9a468241f369f4c7e73a95ba9a5772dac90e0ce1