### PR TITLE
Fix parser exception cannot be caught

### DIFF
--- a/src/main/java/com/baidu/hugegraph/loader/HugeGraphLoader.java
+++ b/src/main/java/com/baidu/hugegraph/loader/HugeGraphLoader.java
@@ -188,8 +188,11 @@ public class HugeGraphLoader {
     private void loadVertex(VertexBuilder builder) {
         int batchSize = this.options.batchSize;
         List<Vertex> batch = new ArrayList<>(batchSize);
-        while (builder.hasNext()) {
+        while (true) {
             try {
+                if (!builder.hasNext()) {
+                    break;
+                }
                 Vertex vertex = builder.next();
                 batch.add(vertex);
             } catch (ParseException e) {
@@ -253,8 +256,11 @@ public class HugeGraphLoader {
     private void loadEdge(EdgeBuilder builder) {
         int batchSize = this.options.batchSize;
         List<Edge> batch = new ArrayList<>(batchSize);
-        while (builder.hasNext()) {
+        while (true) {
             try {
+                if (!builder.hasNext()) {
+                    break;
+                }
                 Edge edge = builder.next();
                 batch.add(edge);
             } catch (ParseException e) {

--- a/src/main/java/com/baidu/hugegraph/loader/util/JsonUtil.java
+++ b/src/main/java/com/baidu/hugegraph/loader/util/JsonUtil.java
@@ -32,7 +32,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 public final class JsonUtil {
 
-    private static final ObjectMapper mapper = new ObjectMapper();
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     static {
         SimpleModule module = new SimpleModule();
@@ -41,12 +41,12 @@ public final class JsonUtil {
     }
 
     public static void registerModule(Module module) {
-        mapper.registerModule(module);
+        MAPPER.registerModule(module);
     }
 
     public static String toJson(Object object) {
         try {
-            return mapper.writeValueAsString(object);
+            return MAPPER.writeValueAsString(object);
         } catch (JsonProcessingException e) {
             throw new SerializeException("Failed to serialize objects", e);
         }
@@ -54,13 +54,13 @@ public final class JsonUtil {
 
     public static <T> T fromJson(String json, Class<T> clazz) {
         try {
-            return mapper.readValue(json, clazz);
+            return MAPPER.readValue(json, clazz);
         } catch (IOException e) {
             throw new SerializeException("Failed to deserialize json", e);
         }
     }
 
     public static <T> T convert(JsonNode node, Class<T> clazz) {
-        return mapper.convertValue(node, clazz);
+        return MAPPER.convertValue(node, clazz);
     }
 }

--- a/src/test/java/com/baidu/hugegraph/loader/test/functional/FileLoadTest.java
+++ b/src/test/java/com/baidu/hugegraph/loader/test/functional/FileLoadTest.java
@@ -31,9 +31,7 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import com.baidu.hugegraph.loader.HugeGraphLoader;
 import com.baidu.hugegraph.loader.exception.LoadException;
@@ -1251,7 +1249,7 @@ public class FileLoadTest extends LoadTest {
 
     @Test
     public void testParserNotThrowException() {
-        // Here are 3 parser errors, and except no exception thrown
+        // Here are 2 parse errors, and expect no exception thrown
         ioUtil.write("vertex_person.csv",
                      "name,age,city",
                      "p1,marko,22,Beijing",
@@ -1264,9 +1262,8 @@ public class FileLoadTest extends LoadTest {
                 "-g", GRAPH,
                 "-h", SERVER,
                 "--num-threads", "2",
-                "--max-parse-errors", "4"
+                "--max-parse-errors", "3"
         };
-        // TODO: Fix the JVM will exit directly if this test throws exception
         HugeGraphLoader.main(args);
     }
 }

--- a/src/test/java/com/baidu/hugegraph/loader/test/functional/FileLoadTest.java
+++ b/src/test/java/com/baidu/hugegraph/loader/test/functional/FileLoadTest.java
@@ -31,7 +31,9 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import com.baidu.hugegraph.loader.HugeGraphLoader;
 import com.baidu.hugegraph.loader.exception.LoadException;
@@ -1244,6 +1246,27 @@ public class FileLoadTest extends LoadTest {
                 "--num-threads", "2",
                 "--test-mode", "true"
         };
+        HugeGraphLoader.main(args);
+    }
+
+    @Test
+    public void testParserNotThrowException() {
+        // Here are 3 parser errors, and except no exception thrown
+        ioUtil.write("vertex_person.csv",
+                     "name,age,city",
+                     "p1,marko,22,Beijing",
+                     "tom,24,Hongkong",
+                     "jerry,18");
+
+        String[] args = new String[]{
+                "-f", configPath("too_few_columns/struct.json"),
+                "-s", configPath("too_few_columns/schema.groovy"),
+                "-g", GRAPH,
+                "-h", SERVER,
+                "--num-threads", "2",
+                "--max-parse-errors", "4"
+        };
+        // TODO: Fix the JVM will exit directly if this test throws exception
         HugeGraphLoader.main(args);
     }
 }


### PR DESCRIPTION
Fix parser exception cannot be caught

The reason of the problem is that the difference between new & old version of `hasNext()` & `next()`, the new version's `hasNext()` used `parse()` without exception caught.

fix #73 