### PR TITLE
doc: add README for toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,23 @@
-# hugegraph-toolchains
+# hugegraph-toolchain
 
 [![License](https://img.shields.io/badge/license-Apache%202-0E78BA.svg)](https://www.apache.org/licenses/LICENSE-2.0.html)
 [![Build Status](https://github.com/hugegraph/hugegraph-loader/actions/workflows/ci.yml/badge.svg)](https://github.com/hugegraph/hugegraph-loader/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/hugegraph/hugegraph-loader/branch/master/graph/badge.svg)](https://codecov.io/gh/hugegraph/hugegraph-loader)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.baidu.hugegraph/hugegraph-loader/badge.svg)](https://mvnrepository.com/artifact/com.baidu.hugegraph/hugegraph-loader)
 
-`hugegraph-toolchains` is the integration of a series of utilities for [HugeGraph](https://github.com/hugegraph/hugegraph), it includes 4 main modules.
+`hugegraph-toolchain` is the integration project of a series of utilities for [HugeGraph](https://github.com/hugegraph/hugegraph), it includes 4 main modules.
 
 ## Modules
 
 - [hugegraph-loader](./hugegraph-loader): Loading datasets into the HugeGraph from multiple data sources.
 - [hugegraph-hubble](./hugegraph-hubble): Online HugeGraph management and analysis dashboard (Include: data loading, schema management, graph traverser and display)
-- [hugegraph-tools](./hugegraph-tools): Command line tool for deploying, managing and backing up/restoring graphs from HugeGraph.
-- [hugegraph-client](./hugegraph-client): A Java-written client for HugeGraph, providing RESTful graph APIs for schema/gremlin/variables and traversals etc.
+- [hugegraph-tools](./hugegraph-tools): Command line tool for deploying, managing and backing-up/restoring graphs from HugeGraph.
+- [hugegraph-client](./hugegraph-client): A Java-written client for HugeGraph, providing `RESTful` APIs for accessing graph vertex/edge/schema/gremlin/variables and traversals etc.
 
 ## Doc
 
-The [project homepage](https://hugegraph.github.io/hugegraph-doc/) contains more information about `hugegraph-toolchains`. 
+The [project homepage](https://hugegraph.github.io/hugegraph-doc/) contains more information about `hugegraph-toolchain`. 
 
 ## License
 
-hugegraph-toolchains is licensed under `Apache 2.0` License.
+hugegraph-toolchain is licensed under `Apache 2.0` License.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# hugegraph-toolchains
+
+[![License](https://img.shields.io/badge/license-Apache%202-0E78BA.svg)](https://www.apache.org/licenses/LICENSE-2.0.html)
+[![Build Status](https://github.com/hugegraph/hugegraph-loader/actions/workflows/ci.yml/badge.svg)](https://github.com/hugegraph/hugegraph-loader/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/hugegraph/hugegraph-loader/branch/master/graph/badge.svg)](https://codecov.io/gh/hugegraph/hugegraph-loader)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.baidu.hugegraph/hugegraph-loader/badge.svg)](https://mvnrepository.com/artifact/com.baidu.hugegraph/hugegraph-loader)
+
+`hugegraph-toolchains` is the integration of a series of utilities for [HugeGraph](https://github.com/hugegraph/hugegraph), it includes 4 main modules.
+
+## Modules
+
+- [hugegraph-loader](./hugegraph-loader): Loading datasets into the HugeGraph from multiple data sources.
+- [hugegraph-hubble](./hugegraph-hubble): Online HugeGraph management and analysis dashboard (Include: data loading, schema management, graph traverser and display)
+- [hugegraph-tools](./hugegraph-tools): Command line tool for deploying, managing and backing up/restoring graphs from HugeGraph.
+- [hugegraph-client](./hugegraph-client): A Java-written client for HugeGraph, providing RESTful graph APIs for schema/gremlin/variables and traversals etc.
+
+## Doc
+
+The [project homepage](https://hugegraph.github.io/hugegraph-doc/) contains more information about `hugegraph-toolchains`. 
+
+## License
+
+hugegraph-toolchains is licensed under `Apache 2.0` License.

--- a/hugegraph-client/README.md
+++ b/hugegraph-client/README.md
@@ -15,5 +15,9 @@ hugegraph-client is a Java-written client of [HugeGraph](https://github.com/huge
 - RESTful Traversals, shortest path, k-out, k-neighbor, paths and crosspoints etc.
 - Variables, CRUD of variables
 
+## Doc
+
+The [client homepage](https://hugegraph.github.io/hugegraph-doc/quickstart/hugegraph-client.html) contains more information about it.
+
 ## Licence
 The same as HugeGraph, hugegraph-client is also licensed under Apache 2.0 License.

--- a/hugegraph-hubble/README.md
+++ b/hugegraph-hubble/README.md
@@ -11,11 +11,11 @@ hugegraph-hubble is a graph management and analysis platform that provides featu
 - Graph connection management, supporting to easily switch graph to operate
 - Graph data load, supporting to load large amounts of data from files into hugegraph-server
 - Schema management, supporting to easily perform schema manipulation and display
-- graph analysis and graphical display, supporting to build query via gremlin or algorithms with a little effort then will get cool graphical results
+- Graph analysis and graphical display, supporting to build query via the gremlin or algorithms with a little effort then will get cool graphical results
 
-## Learn More
+## Doc
 
-[The project homepage](https://hugegraph.github.io/hugegraph-doc/quickstart/hugegraph-hubble.html) contains more information about hugegraph-hubble.
+[The hubble homepage](https://hugegraph.github.io/hugegraph-doc/quickstart/hugegraph-hubble.html) contains more information about it.
 
 ## License
 

--- a/hugegraph-loader/README.md
+++ b/hugegraph-loader/README.md
@@ -34,9 +34,9 @@ To build with default tests:
 mvn clean install
 ```
 
-## Learn More
+## Doc
 
-The [project homepage](https://hugegraph.github.io/hugegraph-doc/) contains more information about hugegraph-loader. 
+The [loader homepage](https://hugegraph.github.io/hugegraph-doc/quickstart/hugegraph-loader.html) contains more information about it. 
 
 ## License
 

--- a/hugegraph-tools/README.md
+++ b/hugegraph-tools/README.md
@@ -10,7 +10,7 @@ HugeGraph-Tools is a customizable command line utility for deploying, managing a
 
 ## Learn More
 
-The [project homepage](https://hugegraph.github.io/hugegraph-doc/quickstart/hugegraph-tools.html) contains more information about HugeGraph-Tools. 
+The [tools homepage](https://hugegraph.github.io/hugegraph-doc/quickstart/hugegraph-tools.html) contains more information about it. 
 
 ## License
 


### PR DESCRIPTION
after merge to apache, we need do

- [ ] update all urls in `README.md`
- [ ] update some `loader` link to `toolchains`
- [ ] we should better unify the version for loader/hubble/tools with the server to keep consistency